### PR TITLE
Implements to register label for reading_vimrc bot in gitter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 file loading tool for [vimrc読書会](http://vim-jp.org/reading-vimrc/)
 
 ## Usage
-```
+```vim
 ReadingVimrcLoad
+
+" register label to clipboard
+vmap <Leader><CR> <Plug>(reading_vimrc-update_clipboard)
 ```
 
 ## License

--- a/autoload/reading_vimrc.vim
+++ b/autoload/reading_vimrc.vim
@@ -43,5 +43,14 @@ function! reading_vimrc#load()
   call s:load_vimrcs(vimrcs[0]['vimrcs'])
 endfunction
 
+" update clipboard for reading-vimrc bot in gitter.
+function! reading_vimrc#update_clipboard() range
+  let splited_name = split(expand('%'), '/')
+  let filename = splited_name[len(splited_name) - 1]
+  let label = printf('%s#L%s-%s', filename, a:firstline, a:lastline)
+  let @+ = label
+  echo 'Updated clipboard : ' . label
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/reading_vimrc.vim
+++ b/plugin/reading_vimrc.vim
@@ -15,6 +15,7 @@ command! -nargs=0
       \ ReadingVimrcLoad
       \ call reading_vimrc#load()
 
+vnoremap <Plug>(reading_vimrc-update_clipboard) :call reading_vimrc#update_clipboard()<CR>
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
### About

- Add mapping in visual mode `<Plug> (reading_vimrc-update_clipboard)`

### demo

![l](https://cloud.githubusercontent.com/assets/9594376/21417685/a54399cc-c85f-11e6-9f02-3a9592c0b15f.gif)
