### PR TITLE
Improve content buffer

### DIFF
--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -59,4 +59,5 @@ function! reading_vimrc#buffer#load_content(path) abort
   1 delete _
   setlocal buftype=nofile bufhidden=hide noswapfile
   setlocal readonly nomodifiable nomodeline number norelativenumber
+  filetype detect
 endfunction

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -54,6 +54,9 @@ function! reading_vimrc#buffer#load_content(path) abort
   let parsed_name = reading_vimrc#buffer#parse_name(a:path)
   let raw_url = reading_vimrc#url#raw_github_url(parsed_name)
   let response = s:HTTP.get(raw_url)
+  setlocal noreadonly modifiable
   put =response.content
   1 delete _
+  setlocal buftype=nofile bufhidden=hide noswapfile
+  setlocal readonly nomodifiable nomodeline number norelativenumber
 endfunction

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -46,12 +46,12 @@ function! reading_vimrc#buffer#info_list() abort
 endfunction
 
 " load vimrc buffer content from github
-function! reading_vimrc#buffer#load_content() abort
+function! reading_vimrc#buffer#load_content(path) abort
   if line('$') > 1 || getline(1) != ''
     return
   endif
 
-  let parsed_name = reading_vimrc#buffer#parse_name(bufname('%'))
+  let parsed_name = reading_vimrc#buffer#parse_name(a:path)
   let raw_url = reading_vimrc#url#raw_github_url(parsed_name)
   let response = s:HTTP.get(raw_url)
   put =response.content

--- a/plugin/reading_vimrc.vim
+++ b/plugin/reading_vimrc.vim
@@ -23,7 +23,8 @@ vnoremap <Plug>(reading_vimrc-update_clipboard) :call reading_vimrc#update_clipb
 
 augroup reading_vimrc
   autocmd!
-  autocmd BufEnter reading-vimrc://* call reading_vimrc#buffer#load_content()
+  autocmd BufReadCmd reading-vimrc://*
+  \   call reading_vimrc#buffer#load_content(expand('<amatch>'))
 augroup END
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
バッファの読み込みに `BufReadCmd` を使うようにしました。これは存在しない架空のファイルの内容を読み込むのに使う autocmd で、今回のようなケースではこちらを使うのが良いです。
また、開いたバッファにいくつかオプションを設定して、リードオンリーバッファにしました。