### PR TITLE
Next info buffer

### DIFF
--- a/autoload/reading_vimrc.vim
+++ b/autoload/reading_vimrc.vim
@@ -47,6 +47,12 @@ function! reading_vimrc#list()
   endfor
 endfunction
 
+" open reading-vimrc://next
+function! reading_vimrc#next()
+  let bufname = reading_vimrc#buffer#name({'nth': 'next'})
+  execute 'new' fnameescape(bufname)
+endfunction
+
 " update clipboard for reading-vimrc bot in gitter.
 function! reading_vimrc#update_clipboard() range
   let splited_name = split(expand('%'), '/')

--- a/autoload/reading_vimrc.vim
+++ b/autoload/reading_vimrc.vim
@@ -24,9 +24,10 @@ function! s:fetch_next_json()
 endfunction
 
 " create buffers of vimrcs
-function! s:load_vimrcs(vimrcs)
+function! s:load_vimrcs(vimrcs, nth)
   for vimrc in a:vimrcs
     let parsed_url = reading_vimrc#url#parse_github_url(vimrc['url'])
+    let parsed_url.nth = a:nth
     let buffer_name = reading_vimrc#buffer#name(parsed_url)
     execute 'badd ' . buffer_name
   endfor
@@ -35,7 +36,7 @@ endfunction
 " load reading-vimrc files
 function! reading_vimrc#load()
   let vimrcs = s:fetch_next_json()
-  call s:load_vimrcs(vimrcs[0]['vimrcs'])
+  call s:load_vimrcs(vimrcs[0]['vimrcs'], 'next')
 endfunction
 
 " show reading-vimrc buffer list

--- a/autoload/reading_vimrc.vim
+++ b/autoload/reading_vimrc.vim
@@ -12,7 +12,7 @@ let s:JSON = s:V.import('Web.JSON')
 let s:NEXT_JSON_URL = 'http://vim-jp.org/reading-vimrc/json/next.json'
 
 " fetch next.json from reading-vimrc website
-function! s:fetch_next_json()
+function! reading_vimrc#fetch_next_json()
   if exists('s:next_json')
     return s:next_json
   endif
@@ -35,7 +35,7 @@ endfunction
 
 " load reading-vimrc files
 function! reading_vimrc#load()
-  let vimrcs = s:fetch_next_json()
+  let vimrcs = reading_vimrc#fetch_next_json()
   call s:load_vimrcs(vimrcs[0]['vimrcs'], 'next')
 endfunction
 

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -23,17 +23,6 @@ function! reading_vimrc#buffer#name(info) abort
         \       a:info.path)
 endfunction
 
-" register vimrc file as empty buffer
-function! reading_vimrc#buffer#register(url) abort
-  let file_info = reading_vimrc#url#parse_github_url(a:url)
-  if empty(file_info)
-    return
-  endif
-
-  let buffer_name = reading_vimrc#buffer#name(file_info)
-  execute 'badd' buffer_name
-endfunction
-
 " return vimrc buffer info list
 function! reading_vimrc#buffer#info_list() abort
   let info_list = []

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -3,20 +3,22 @@ let s:HTTP = s:V.import('Web.HTTP')
 
 " parse buffer name to file info dictionary
 function! reading_vimrc#buffer#parse_name(name) abort
-  let pattern = 'reading-vimrc://\([^/]\+\)/\([^/]\+\)/\([^/]\+\)/\(.\+\)$'
+  let pattern = 'reading-vimrc://\([^/]\+\)/\([^/]\+\)/\([^/]\+\)/\([^/]\+\)/\(.\+\)$'
   let results = matchlist(a:name, pattern)
 
   return {
-        \  'user': results[1],
-        \  'repo': results[2],
-        \  'branch': results[3],
-        \  'path': results[4]
+        \  'nth': results[1],
+        \  'user': results[2],
+        \  'repo': results[3],
+        \  'branch': results[4],
+        \  'path': results[5]
         \ }
 endfunction
 
 " build buffer name from file info dictionary
 function! reading_vimrc#buffer#name(info) abort
-  return printf('reading-vimrc://%s/%s/%s/%s',
+  return printf('reading-vimrc://%s/%s/%s/%s/%s',
+        \       a:info.nth,
         \       a:info.user,
         \       a:info.repo,
         \       a:info.branch,

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -3,16 +3,19 @@ let s:HTTP = s:V.import('Web.HTTP')
 
 " parse buffer name to file info dictionary
 function! reading_vimrc#buffer#parse_name(name) abort
-  let pattern = 'reading-vimrc://\([^/]\+\)/\([^/]\+\)/\([^/]\+\)/\([^/]\+\)/\(.\+\)$'
-  let results = matchlist(a:name, pattern)
-
-  return {
-        \  'nth': results[1],
-        \  'user': results[2],
-        \  'repo': results[3],
-        \  'branch': results[4],
-        \  'path': results[5]
-        \ }
+  let paths = split(matchstr(a:name, 'reading-vimrc://\zs.*'), '/')
+  let full_keys = ['nth', 'user', 'repo', 'branch', 'path']
+  let keys_num = len(full_keys)
+  let keys = full_keys[0 : min([keys_num, len(paths)]) - 1]
+  if len(keys) == keys_num
+    let path_part = join(paths[keys_num - 1 : -1], '/')
+    let paths = paths[0 : keys_num - 2] + [path_part]
+  endif
+  let info = {}
+  for i in range(len(keys))
+    let info[keys[i]] = paths[i]
+  endfor
+  return info
 endfunction
 
 " build buffer name from file info dictionary

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -46,11 +46,9 @@ function! reading_vimrc#buffer#load_content(path) abort
   if has_key(parsed_name, 'path')
     let raw_url = reading_vimrc#url#raw_github_url(parsed_name)
     let response = s:HTTP.get(raw_url)
-    setlocal noreadonly modifiable
-    put =response.content
-    1 delete _
     setlocal buftype=nofile bufhidden=hide noswapfile
-    setlocal readonly nomodifiable nomodeline number norelativenumber
+    setlocal nomodeline number norelativenumber
+    call s:set_content(response.content)
     filetype detect
   else
     call s:show_info_page(parsed_name.nth)
@@ -71,11 +69,9 @@ function! s:show_info_page(nth) abort
         \ ]
   let content = header + map(copy(info.vimrcs), 'v:val.name')
 
-  setlocal noreadonly modifiable
-  put =content
-  1 delete _
   setlocal buftype=nofile bufhidden=hide noswapfile
-  setlocal readonly nomodifiable nomodeline nonumber norelativenumber
+  setlocal nomodeline nonumber norelativenumber
+  call s:set_content(content)
 
   nnoremap <buffer> <silent> <Plug>(reading-vimrc-open-file)
         \  :<C-u>call <SID>open_vimrc(line('.') - 4)<CR>
@@ -92,4 +88,11 @@ function! s:open_vimrc(n) abort
   let info.nth = b:reading_vimrc_info.nth
   let bufname = reading_vimrc#buffer#name(info)
   new `=bufname`
+endfunction
+
+function! s:set_content(content) abort
+  setlocal noreadonly modifiable
+  put =a:content
+  1 delete _
+  setlocal readonly nomodifiable
 endfunction

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -92,7 +92,7 @@ endfunction
 
 function! s:set_content(content) abort
   setlocal noreadonly modifiable
-  put =a:content
-  1 delete _
+  silent put =a:content
+  silent 1 delete _
   setlocal readonly nomodifiable
 endfunction

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -20,12 +20,9 @@ endfunction
 
 " build buffer name from file info dictionary
 function! reading_vimrc#buffer#name(info) abort
-  return printf('reading-vimrc://%s/%s/%s/%s/%s',
-        \       a:info.nth,
-        \       a:info.user,
-        \       a:info.repo,
-        \       a:info.branch,
-        \       a:info.path)
+  let full_keys = ['nth', 'user', 'repo', 'branch', 'path']
+  let paths = map(full_keys, 'get(a:info, v:val, "")')
+  return 'reading-vimrc://' . join(filter(paths, 'v:val !=# ""'), '/')
 endfunction
 
 " return vimrc buffer info list

--- a/doc/reading_vimrc.txt
+++ b/doc/reading_vimrc.txt
@@ -40,6 +40,10 @@ COMMANDS					*reading_vimrc-commands*
 :ReadingVimrcList				*:ReadingVimrcList*
 	Do |:ReadingVimrcLoad| and show created buffer names.
 
+:ReadingVimrcNext				*:ReadingVimrcNext*
+	Open "reading-vimrc://next".  It shows next reading-vimrc info.
+	And you can open files with <CR> when cursor on a file.
+
 
 ------------------------------------------------------------------------------
 KEY-MAPPINGS					*reading_vimrc-key-mappings*

--- a/plugin/reading_vimrc.vim
+++ b/plugin/reading_vimrc.vim
@@ -19,6 +19,10 @@ command! -nargs=0
       \ ReadingVimrcList
       \ call reading_vimrc#list()
 
+command! -nargs=0
+      \ ReadingVimrcNext
+      \ call reading_vimrc#next()
+
 vnoremap <Plug>(reading_vimrc-update_clipboard) :call reading_vimrc#update_clipboard()<CR>
 
 augroup reading_vimrc

--- a/test/reading_vimrc/buffer.vim
+++ b/test/reading_vimrc/buffer.vim
@@ -4,12 +4,12 @@ let s:assert = themis#helper('assert')
 function! s:suite.parse_name() abort
   let test_cases = [
         \ {
-        \   'name': 'reading-vimrc://someone/dotfiles/master/.vimrc',
-        \   'expected': {'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': '.vimrc'}
+        \   'name': 'reading-vimrc://next/someone/dotfiles/master/.vimrc',
+        \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': '.vimrc'}
         \ },
         \ {
-        \   'name': 'reading-vimrc://someone/dotfiles/master/vim/.vimrc',
-        \   'expected': {'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'}
+        \   'name': 'reading-vimrc://next/someone/dotfiles/master/vim/.vimrc',
+        \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'}
         \ },
         \ ]
   for tc in test_cases
@@ -20,12 +20,12 @@ endfunction
 function! s:suite.name() abort
   let test_cases = [
         \ {
-        \   'info': {'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': '.vimrc'},
-        \   'expected': 'reading-vimrc://someone/dotfiles/master/.vimrc'
+        \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': '.vimrc'},
+        \   'expected': 'reading-vimrc://next/someone/dotfiles/master/.vimrc'
         \ },
         \ {
-        \   'info': {'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'},
-        \   'expected': 'reading-vimrc://someone/dotfiles/master/vim/.vimrc'
+        \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'},
+        \   'expected': 'reading-vimrc://next/someone/dotfiles/master/vim/.vimrc'
         \ },
         \ ]
   for tc in test_cases

--- a/test/reading_vimrc/buffer.vim
+++ b/test/reading_vimrc/buffer.vim
@@ -35,6 +35,14 @@ function! s:suite.name() abort
         \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'},
         \   'expected': 'reading-vimrc://next/someone/dotfiles/master/vim/.vimrc'
         \ },
+        \ {
+        \   'info': {'nth': 'next'},
+        \   'expected': 'reading-vimrc://next'
+        \ },
+        \ {
+        \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles'},
+        \   'expected': 'reading-vimrc://next/someone/dotfiles'
+        \ },
         \ ]
   for tc in test_cases
     call s:assert.equals(reading_vimrc#buffer#name(tc.info), tc.expected)

--- a/test/reading_vimrc/buffer.vim
+++ b/test/reading_vimrc/buffer.vim
@@ -11,6 +11,14 @@ function! s:suite.parse_name() abort
         \   'name': 'reading-vimrc://next/someone/dotfiles/master/vim/.vimrc',
         \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'}
         \ },
+        \ {
+        \   'name': 'reading-vimrc://next',
+        \   'expected': {'nth': 'next'}
+        \ },
+        \ {
+        \   'name': 'reading-vimrc://next/someone/dotfiles',
+        \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles'}
+        \ },
         \ ]
   for tc in test_cases
     call s:assert.equals(reading_vimrc#buffer#parse_name(tc.name), tc.expected)


### PR DESCRIPTION
`:ReadingVimrcNext` コマンドで以下のような開催情報のバッファを開き、そこからファイル名の上にカーソルを置いて　`<CR>` を押すことでファイルを開けるようにしてみました。
`reading-vimrc://` バッファのバッファ名の先頭に開催回を含められるようにパターンを変えました。将来的に過去の開催回が見れると良いと思っています。
デザインやら機能やらあちこち仮です。無理にこのまま取り込まなくても、叩き台になれば。

```
第 285回 2017-12-16 23:00
Zepprix さん
------
.vimrc
```