### PR TITLE
fix: scheme do not contain '-', remove it.

### DIFF
--- a/autoload/reading_vimrc.vim
+++ b/autoload/reading_vimrc.vim
@@ -47,7 +47,7 @@ function! reading_vimrc#list()
   endfor
 endfunction
 
-" open reading-vimrc://next
+" open readingvimrc://next
 function! reading_vimrc#next()
   let bufname = reading_vimrc#buffer#name({'nth': 'next'})
   execute 'new' fnameescape(bufname)

--- a/autoload/reading_vimrc/buffer.vim
+++ b/autoload/reading_vimrc/buffer.vim
@@ -3,7 +3,7 @@ let s:HTTP = s:V.import('Web.HTTP')
 
 " parse buffer name to file info dictionary
 function! reading_vimrc#buffer#parse_name(name) abort
-  let paths = split(matchstr(a:name, 'reading-vimrc://\zs.*'), '/')
+  let paths = split(matchstr(a:name, 'readingvimrc://\zs.*'), '/')
   let full_keys = ['nth', 'user', 'repo', 'branch', 'path']
   let keys_num = len(full_keys)
   let keys = full_keys[0 : min([keys_num, len(paths)]) - 1]
@@ -22,14 +22,14 @@ endfunction
 function! reading_vimrc#buffer#name(info) abort
   let full_keys = ['nth', 'user', 'repo', 'branch', 'path']
   let paths = map(full_keys, 'get(a:info, v:val, "")')
-  return 'reading-vimrc://' . join(filter(paths, 'v:val !=# ""'), '/')
+  return 'readingvimrc://' . join(filter(paths, 'v:val !=# ""'), '/')
 endfunction
 
 " return vimrc buffer info list
 function! reading_vimrc#buffer#info_list() abort
   let info_list = []
   for info in getbufinfo()
-    if info.name =~# '^reading-vimrc://'
+    if info.name =~# '^readingvimrc://'
       call add(info_list, info)
     endif
   endfor

--- a/doc/reading_vimrc.txt
+++ b/doc/reading_vimrc.txt
@@ -41,7 +41,7 @@ COMMANDS					*reading_vimrc-commands*
 	Do |:ReadingVimrcLoad| and show created buffer names.
 
 :ReadingVimrcNext				*:ReadingVimrcNext*
-	Open "reading-vimrc://next".  It shows next reading-vimrc info.
+	Open "readingvimrc://next".  It shows next reading-vimrc info.
 	And you can open files with <CR> when cursor on a file.
 
 

--- a/plugin/reading_vimrc.vim
+++ b/plugin/reading_vimrc.vim
@@ -27,7 +27,7 @@ vnoremap <Plug>(reading_vimrc-update_clipboard) :call reading_vimrc#update_clipb
 
 augroup reading_vimrc
   autocmd!
-  autocmd BufReadCmd reading-vimrc://*
+  autocmd BufReadCmd readingvimrc://*
   \   call reading_vimrc#buffer#load_content(expand('<amatch>'))
 augroup END
 

--- a/test/reading_vimrc/buffer.vim
+++ b/test/reading_vimrc/buffer.vim
@@ -4,19 +4,19 @@ let s:assert = themis#helper('assert')
 function! s:suite.parse_name() abort
   let test_cases = [
         \ {
-        \   'name': 'reading-vimrc://next/someone/dotfiles/master/.vimrc',
+        \   'name': 'readingvimrc://next/someone/dotfiles/master/.vimrc',
         \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': '.vimrc'}
         \ },
         \ {
-        \   'name': 'reading-vimrc://next/someone/dotfiles/master/vim/.vimrc',
+        \   'name': 'readingvimrc://next/someone/dotfiles/master/vim/.vimrc',
         \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'}
         \ },
         \ {
-        \   'name': 'reading-vimrc://next',
+        \   'name': 'readingvimrc://next',
         \   'expected': {'nth': 'next'}
         \ },
         \ {
-        \   'name': 'reading-vimrc://next/someone/dotfiles',
+        \   'name': 'readingvimrc://next/someone/dotfiles',
         \   'expected': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles'}
         \ },
         \ ]
@@ -29,19 +29,19 @@ function! s:suite.name() abort
   let test_cases = [
         \ {
         \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': '.vimrc'},
-        \   'expected': 'reading-vimrc://next/someone/dotfiles/master/.vimrc'
+        \   'expected': 'readingvimrc://next/someone/dotfiles/master/.vimrc'
         \ },
         \ {
         \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles', 'branch': 'master', 'path': 'vim/.vimrc'},
-        \   'expected': 'reading-vimrc://next/someone/dotfiles/master/vim/.vimrc'
+        \   'expected': 'readingvimrc://next/someone/dotfiles/master/vim/.vimrc'
         \ },
         \ {
         \   'info': {'nth': 'next'},
-        \   'expected': 'reading-vimrc://next'
+        \   'expected': 'readingvimrc://next'
         \ },
         \ {
         \   'info': {'nth': 'next', 'user': 'someone', 'repo': 'dotfiles'},
-        \   'expected': 'reading-vimrc://next/someone/dotfiles'
+        \   'expected': 'readingvimrc://next/someone/dotfiles'
         \ },
         \ ]
   for tc in test_cases


### PR DESCRIPTION
Current vim detect protocol scheme in buffer name.
Protocol scheme bufname specifiy not fix slash/backslash only `/` are path sep.

But protocol scheme accept only alphanumeric chars, don't accept `-`.

This PR remove `-`.
(this PR side effect, work fine in Windows)