### PR TITLE
fix: next.json URL not blob, direct tree URL work fine.

### DIFF
--- a/autoload/reading_vimrc/url.vim
+++ b/autoload/reading_vimrc/url.vim
@@ -1,14 +1,14 @@
 
 " parse github blob url to file info dictionary
 function! reading_vimrc#url#parse_github_url(url) abort
-  let pattern = 'https://github\.com/\([^/]\+\)/\([^/]\+\)/blob/\([^/]\+\)/\(.\+\)$'
+  let pattern = 'https://github\.com/\([^/]\+\)/\([^/]\+\)/\(blob\|tree\)/\([^/]\+\)/\(.\+\)$'
   let results = matchlist(a:url, pattern)
 
   return {
         \  'user': results[1],
         \  'repo': results[2],
-        \  'branch': results[3],
-        \  'path': results[4]
+        \  'branch': results[4],
+        \  'path': results[5]
         \ }
 endfunction
 

--- a/autoload/reading_vimrc/url.vim
+++ b/autoload/reading_vimrc/url.vim
@@ -1,14 +1,14 @@
 
 " parse github blob url to file info dictionary
 function! reading_vimrc#url#parse_github_url(url) abort
-  let pattern = 'https://github\.com/\([^/]\+\)/\([^/]\+\)/\(blob\|tree\)/\([^/]\+\)/\(.\+\)$'
+  let pattern = 'https://github\.com/\([^/]\+\)/\([^/]\+\)/\%(blob\|tree\)/\([^/]\+\)/\(.\+\)$'
   let results = matchlist(a:url, pattern)
 
   return {
         \  'user': results[1],
         \  'repo': results[2],
-        \  'branch': results[4],
-        \  'path': results[5]
+        \  'branch': results[3],
+        \  'path': results[4]
         \ }
 endfunction
 


### PR DESCRIPTION
<details><summary>see 2020/10/10 reading json</summary>
<p>
json file

```json
[ 
  {
    "id" : 432,
    "date" : "2020-10-10 23:00",
    "author" : {
        "name": "tjdevries",
        "url": "https://github.com/tjdevries"
    },
    "vimrcs" : [
      
        {
          "name": "init.vim",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/init.vim",
          "hash": ""
        } ,
      
        {
          "name": "ginit.vim",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/ginit.vim",
          "hash": ""
        } ,
      
        {
          "name": "tj.vim",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/autoload/tj.vim",
          "hash": ""
        } ,
      
        {
          "name": "_other_colors.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/_other_colors.lua",
          "hash": ""
        } ,
      
        {
          "name": "diagnostics.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/custom/diagnostics.lua",
          "hash": ""
        } ,
      
        {
          "name": "floating_text.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/custom/floating_text.lua",
          "hash": ""
        } ,
      
        {
          "name": "functional.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/custom/functional.lua",
          "hash": ""
        } ,
      
        {
          "name": "inspector.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/custom/inspector.lua",
          "hash": ""
        } ,
      
        {
          "name": "lsp_override.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/custom/lsp_override.lua",
          "hash": ""
        } ,
      
        {
          "name": "mappings.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/custom/mappings.lua",
          "hash": ""
        } ,
      
        {
          "name": "find_require.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/find_require.lua",
          "hash": ""
        } ,
      
        {
          "name": "init.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/init.lua",
          "hash": ""
        } ,
      
        {
          "name": "inspect.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/inspect.lua",
          "hash": ""
        } ,
      
        {
          "name": "lsp_config.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/lsp_config.lua",
          "hash": ""
        } ,
      
        {
          "name": "sourcegraph_ts.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/nvim_lsp/sourcegraph_ts.lua",
          "hash": ""
        } ,
      
        {
          "name": "plugins.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/plugins.lua",
          "hash": ""
        } ,
      
        {
          "name": "reload.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/reload.lua",
          "hash": ""
        } ,
      
        {
          "name": "completion.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/completion.lua",
          "hash": ""
        } ,
      
        {
          "name": "lsp_extensions.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/lsp_extensions.lua",
          "hash": ""
        } ,
      
        {
          "name": "lsp_status.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/lsp_status.lua",
          "hash": ""
        } ,
      
        {
          "name": "nvim_dev.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/nvim_dev.lua",
          "hash": ""
        } ,
      
        {
          "name": "plenary.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/plenary.lua",
          "hash": ""
        } ,
      
        {
          "name": "repl.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/repl.lua",
          "hash": ""
        } ,
      
        {
          "name": "snippets.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/snippets.lua",
          "hash": ""
        } ,
      
        {
          "name": "statusline.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/statusline.lua",
          "hash": ""
        } ,
      
        {
          "name": "telescope.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/telescope.lua",
          "hash": ""
        } ,
      
        {
          "name": "treesitter.lua",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/lua/tj/treesitter.lua",
          "hash": ""
        } ,
      
        {
          "name": "keymaps.vim",
          "url": "https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/plugin/keymaps.vim",
          "hash": ""
        } 
      
    ],
    "part": "",
    "other": ""
  } 
 ]
```
</p>
</details>

URL as `https://github.com/tjdevries/config_manager/tree/master/xdg_config/nvim/plugin/keymaps.vim`.
That is not blob.

Fix match rule